### PR TITLE
Upgrade browserify; Fix TypeError bug.

### DIFF
--- a/dep-case-verify.js
+++ b/dep-case-verify.js
@@ -19,10 +19,12 @@ function pathSteps(pathString) {
 function error(stream, row, step) {
   var id = path.relative(process.cwd(), row.id);
   Object.keys(row.deps).some(function(key) {
-    if (row.deps[key].indexOf(step) !== -1) {
-      var err = new Error('Unmatched case in "' + id + '" for "' + key + '"');
-      stream.emit('error', err);
-      return true;
+    if (typeof row.deps[key] === 'string') {
+      if (row.deps[key].indexOf(step) !== -1) {
+        var err = new Error('Unmatched case in "' + id + '" for "' + key + '"');
+        stream.emit('error', err);
+        return true;
+      }
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "through2": "^0.6.3"
   },
   "devDependencies": {
-    "browserify": "^8.0.0",
+    "browserify": "^9.0.0",
     "tape": "^3.4.0",
     "underscore": "^1.7.0"
   }


### PR DESCRIPTION
- [x] Upgrade Browserify dependency.
- [x] Add protection around `row.deps[key].indexOf` in case `row.deps[key]` isn't a string.

**Note:** This probably will require at least a minor version bump in NPM.
